### PR TITLE
Fix big endian builds

### DIFF
--- a/.github/workflows/cmake-big-endian-s390x.yml
+++ b/.github/workflows/cmake-big-endian-s390x.yml
@@ -1,0 +1,40 @@
+name: CMake on big-endian s390x
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install cross toolchain and QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            ninja-build \
+            qemu-user \
+            qemu-user-binfmt \
+            gcc-s390x-linux-gnu \
+            g++-s390x-linux-gnu \
+            libc6-dev-s390x-cross
+
+      - name: Configure CMake
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build-s390x -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=s390x-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=s390x-linux-gnu-g++ \
+            -DCMAKE_CROSSCOMPILING_EMULATOR='qemu-s390x;-L;/usr/s390x-linux-gnu'
+
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/build-s390x
+
+      - name: Test
+        run: ctest --test-dir ${{ github.workspace }}/build-s390x --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(bigint LANGUAGES C CXX VERSION 2.3)
+project(bigint LANGUAGES C CXX VERSION 2.4)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import cmake_layout, CMakeToolchain, CMakeDeps, CMake
 
 class bigint23(ConanFile):
     name = "bigint23"
-    version = "2.3"
+    version = "2.4"
 
     license = "MIT"
     author = "Rene Windegger <rene@windegger.wtf>"

--- a/include/bigint23/bigint.hpp
+++ b/include/bigint23/bigint.hpp
@@ -452,7 +452,7 @@ namespace bigint {
                         if (i + j >= n) {
                             break;
                         }
-                        auto const idx2 = std::size_t{m - 1 - j};
+                        auto const idx2 = std::size_t{n - 1 - j};
                         auto const result_idx = std::size_t{n - 1 - (i + j)};
                         auto product = std::uint32_t{
                             static_cast<std::uint32_t>(abs_this.data_[idx1]) *

--- a/include/bigint23/bigint.hpp
+++ b/include/bigint23/bigint.hpp
@@ -1019,12 +1019,12 @@ namespace bigint {
     template<BitWidth bits, Signedness signedness>
     constexpr std::ostream &print_hex(std::ostream &os, bigint<bits, signedness> const &data, bool const use_uppercase) {
         auto const &buf = data.data_;
-        auto start = buf.size();
-        while (start > 1 and buf[start - 1] == 0) {
-            --start;
-        }
 
         if constexpr (std::endian::native == std::endian::little) {
+            auto start = buf.size();
+            while (start > 1 and buf[start - 1] == 0) {
+                --start;
+            }
             for (auto const i: std::views::reverse(std::views::iota(0uz, start))) {
                 auto local = std::array<char, 3>{};
                 std::snprintf(
@@ -1036,7 +1036,11 @@ namespace bigint {
                 os.write(local.data(), local.size() - 1);
             }
         } else {
-            for (auto const i: std::views::iota(0uz, start)) {
+            auto start = 0uz;
+            while (start < buf.size() - 1 and buf[start] == 0) {
+                ++start;
+            }
+            for (auto const i: std::views::iota(start, buf.size())) {
                 auto local = std::array<char, 3>{};
                 std::snprintf(
                     local.data(),
@@ -1066,7 +1070,12 @@ namespace bigint {
 
         while (temp != std::int8_t{0}) {
             auto r = temp % std::int8_t{8};
-            auto digit = r.data_[0];
+            auto digit = std::uint8_t{0};
+            if constexpr (std::endian::native == std::endian::little) {
+                digit = r.data_[0];
+            } else {
+                digit = r.data_[r.data_.size() - 1];
+            }
             *--pos = static_cast<char>('0' + digit);
             temp /= std::int8_t{8};
         }
@@ -1099,7 +1108,12 @@ namespace bigint {
 
         while (temp != std::int8_t{0}) {
             auto r = temp % std::int8_t{10};
-            auto digit = r.data_[0];
+            auto digit = std::uint8_t{0};
+            if constexpr (std::endian::native == std::endian::little) {
+                digit = r.data_[0];
+            } else {
+                digit = r.data_[r.data_.size() - 1];
+            }
             *--pos = static_cast<char>('0' + digit);
             temp /= std::int8_t{10};
         }

--- a/include/bigint23/bigint.hpp
+++ b/include/bigint23/bigint.hpp
@@ -75,7 +75,7 @@ namespace bigint {
                     data_[i] = other.data_[i];
                 }
             } else {
-                for (auto const i: std::views::reverse(std::views::iota(1uz, other.data_.size() + 1))) {
+                for (auto const i: std::views::iota(0uz, other.data_.size())) {
                     data_[data_.size() - i - 1] = other.data_[other.data_.size() - i - 1];
                 }
             }

--- a/include/bigint23/bigint.hpp
+++ b/include/bigint23/bigint.hpp
@@ -574,18 +574,40 @@ namespace bigint {
                 throw std::overflow_error("Division by zero");
             }
 
+            auto negative_result = false;
+            auto abs_this = bigint{*this};
+            auto abs_other = bigint{other};
+
+            if constexpr (signedness == Signedness::Signed) {
+                if (*this < std::int8_t{0}) {
+                    negative_result = !negative_result;
+                    abs_this = -*this;
+                }
+            }
+            if constexpr (other_signedness == Signedness::Signed) {
+                if (other < std::int8_t{0}) {
+                    negative_result = !negative_result;
+                    abs_other = -abs_other;
+                }
+            }
+
             auto quotient = bigint{};
             auto remainder = bigint{};
             static constexpr auto total_bits = std::to_underlying(bits);
 
             for (auto const i: std::views::reverse(std::views::iota(0uz, total_bits))) {
                 remainder <<= std::int8_t{1};
-                if (this->get_bit(i)) {
+                if (abs_this.get_bit(i)) {
                     remainder += std::int8_t{1};
                 }
-                if (remainder >= other) {
-                    remainder -= other;
+                if (remainder >= abs_other) {
+                    remainder -= abs_other;
                     quotient.set_bit(i, true);
+                }
+            }
+            if constexpr (signedness == Signedness::Signed) {
+                if (negative_result) {
+                    quotient = -quotient;
                 }
             }
             *this = quotient;
@@ -618,17 +640,38 @@ namespace bigint {
                 throw std::overflow_error("Division by zero");
             }
 
+            auto negative_result = false;
+            auto abs_this = bigint{*this};
+            auto abs_other = bigint{other};
+
+            if constexpr (signedness == Signedness::Signed) {
+                if (*this < std::int8_t{0}) {
+                    negative_result = true;
+                    abs_this = -*this;
+                }
+            }
+            if constexpr (other_signedness == Signedness::Signed) {
+                if (other < std::int8_t{0}) {
+                    abs_other = -abs_other;
+                }
+            }
+
             auto remainder = bigint{};
             static constexpr auto total_bits = std::to_underlying(bits);
 
             for (auto const i: std::views::reverse(std::views::iota(0uz, total_bits))) {
                 remainder <<= std::int8_t{1};
-                if (this->get_bit(i)) {
+                if (abs_this.get_bit(i)) {
                     remainder += std::int8_t{1};
                 }
 
-                if (remainder >= other) {
-                    remainder -= other;
+                if (remainder >= abs_other) {
+                    remainder -= abs_other;
+                }
+            }
+            if constexpr (signedness == Signedness::Signed) {
+                if (negative_result) {
+                    remainder = -remainder;
                 }
             }
             *this = remainder;
@@ -664,12 +707,22 @@ namespace bigint {
                 }
             }
 
-            auto carry = std::uint16_t{0};
-            for (auto const i: std::views::iota(0uz, n)) {
-                auto const temp = static_cast<std::uint16_t>(
-                    (static_cast<std::uint16_t>(result[i]) << bit_shift) | carry);
-                result[i] = static_cast<std::uint8_t>(temp & 0xFF);
-                carry = temp >> 8;
+            if constexpr (std::endian::native == std::endian::little) {
+                auto carry = std::uint16_t{0};
+                for (auto const i: std::views::iota(0uz, n)) {
+                    auto const temp = static_cast<std::uint16_t>(
+                        (static_cast<std::uint16_t>(result[i]) << bit_shift) | carry);
+                    result[i] = static_cast<std::uint8_t>(temp & 0xFF);
+                    carry = temp >> 8;
+                }
+            } else {
+                auto carry = std::uint16_t{0};
+                for (auto const i: std::views::reverse(std::views::iota(0uz, n))) {
+                    auto const temp = static_cast<std::uint16_t>(
+                        (static_cast<std::uint16_t>(result[i]) << bit_shift) | carry);
+                    result[i] = static_cast<std::uint8_t>(temp & 0xFF);
+                    carry = temp >> 8;
+                }
             }
 
             data_ = result;

--- a/include/bigint23/bigint.hpp
+++ b/include/bigint23/bigint.hpp
@@ -574,40 +574,18 @@ namespace bigint {
                 throw std::overflow_error("Division by zero");
             }
 
-            auto negative_result = false;
-            auto abs_this = bigint{*this};
-            auto abs_other = bigint{other};
-
-            if constexpr (signedness == Signedness::Signed) {
-                if (*this < std::int8_t{0}) {
-                    negative_result = !negative_result;
-                    abs_this = -*this;
-                }
-            }
-            if constexpr (other_signedness == Signedness::Signed) {
-                if (other < std::int8_t{0}) {
-                    negative_result = !negative_result;
-                    abs_other = -abs_other;
-                }
-            }
-
             auto quotient = bigint{};
             auto remainder = bigint{};
             static constexpr auto total_bits = std::to_underlying(bits);
 
             for (auto const i: std::views::reverse(std::views::iota(0uz, total_bits))) {
                 remainder <<= std::int8_t{1};
-                if (abs_this.get_bit(i)) {
+                if (this->get_bit(i)) {
                     remainder += std::int8_t{1};
                 }
-                if (remainder >= abs_other) {
-                    remainder -= abs_other;
+                if (remainder >= other) {
+                    remainder -= other;
                     quotient.set_bit(i, true);
-                }
-            }
-            if constexpr (signedness == Signedness::Signed) {
-                if (negative_result) {
-                    quotient = -quotient;
                 }
             }
             *this = quotient;
@@ -640,38 +618,17 @@ namespace bigint {
                 throw std::overflow_error("Division by zero");
             }
 
-            auto negative_result = false;
-            auto abs_this = bigint{*this};
-            auto abs_other = bigint{other};
-
-            if constexpr (signedness == Signedness::Signed) {
-                if (*this < std::int8_t{0}) {
-                    negative_result = true;
-                    abs_this = -*this;
-                }
-            }
-            if constexpr (other_signedness == Signedness::Signed) {
-                if (other < std::int8_t{0}) {
-                    abs_other = -abs_other;
-                }
-            }
-
             auto remainder = bigint{};
             static constexpr auto total_bits = std::to_underlying(bits);
 
             for (auto const i: std::views::reverse(std::views::iota(0uz, total_bits))) {
                 remainder <<= std::int8_t{1};
-                if (abs_this.get_bit(i)) {
+                if (this->get_bit(i)) {
                     remainder += std::int8_t{1};
                 }
 
-                if (remainder >= abs_other) {
-                    remainder -= abs_other;
-                }
-            }
-            if constexpr (signedness == Signedness::Signed) {
-                if (negative_result) {
-                    remainder = -remainder;
+                if (remainder >= other) {
+                    remainder -= other;
                 }
             }
             *this = remainder;

--- a/tests/functions_tests.cpp
+++ b/tests/functions_tests.cpp
@@ -6,12 +6,7 @@
 #include <gtest/gtest.h>
 
 TEST(bigint23, byteswap_test) {
-    bigint::bigint<bigint::BitWidth{128}, bigint::Signedness::Unsigned> expected;
-    if constexpr (std::endian::native == std::endian::little) {
-        expected = "0x78563412000000000000000000000000";
-    } else {
-        expected = "0x12345678";
-    }
+    bigint::bigint<bigint::BitWidth{128}, bigint::Signedness::Unsigned> const expected = "0x78563412000000000000000000000000";
     bigint::bigint<bigint::BitWidth{128}, bigint::Signedness::Unsigned> const input = 0x12345678;
     auto actual = byteswap(input);
     auto const actual_ptr = reinterpret_cast<char const *>(std::addressof(actual));


### PR DESCRIPTION
This pull request adds support for big-endian architectures, specifically targeting s390x, and updates the codebase to handle endianness correctly throughout. The project version is incremented to 2.4 to reflect these improvements. The most important changes are as follows:

**Endianness Support and Cross-Platform Compatibility:**

* Added a new GitHub Actions workflow (`.github/workflows/cmake-big-endian-s390x.yml`) to build and test the project on big-endian s390x using cross-compilation and QEMU emulation.
* Updated various algorithms in `bigint.hpp` to handle both little-endian and big-endian architectures, including correct data access, iteration order, and output formatting for arithmetic and printing functions. [[1]](diffhunk://#diff-064a8eaa00902aa51d0af638524ba4ef9f19c0b5576d0d7c6b11a1e7229f4a46L78-R78) [[2]](diffhunk://#diff-064a8eaa00902aa51d0af638524ba4ef9f19c0b5576d0d7c6b11a1e7229f4a46L455-R455) [[3]](diffhunk://#diff-064a8eaa00902aa51d0af638524ba4ef9f19c0b5576d0d7c6b11a1e7229f4a46R667-R683) [[4]](diffhunk://#diff-064a8eaa00902aa51d0af638524ba4ef9f19c0b5576d0d7c6b11a1e7229f4a46R1022-L1017) [[5]](diffhunk://#diff-064a8eaa00902aa51d0af638524ba4ef9f19c0b5576d0d7c6b11a1e7229f4a46L1029-R1043) [[6]](diffhunk://#diff-064a8eaa00902aa51d0af638524ba4ef9f19c0b5576d0d7c6b11a1e7229f4a46L1059-R1078) [[7]](diffhunk://#diff-064a8eaa00902aa51d0af638524ba4ef9f19c0b5576d0d7c6b11a1e7229f4a46L1092-R1116)

**Version Updates:**

* Bumped project version from 2.3 to 2.4 in `CMakeLists.txt` and `conanfile.py` to reflect the new features and compatibility. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL3-R3) [[2]](diffhunk://#diff-63f09721ade419d29886e8190ffa3c9c756baa9bef8802a7f2aeabf3b545164fL6-R6)

**Testing Adjustments:**

* Updated the `byteswap_test` in `functions_tests.cpp` to expect the same output regardless of host endianness, aligning with the new consistent behavior.This pull request adds a new GitHub Actions workflow to enable cross-compiling and testing the project for the big-endian s390x architecture using CMake, QEMU, and the s390x cross toolchain.

CI/CD and cross-compilation support:

* Added a new workflow file `.github/workflows/cmake-big-endian-s390x.yml` that sets up a CI job to cross-compile, build, and test the project for the s390x architecture using QEMU emulation and the appropriate cross toolchain.